### PR TITLE
Fix http clipboard copy error

### DIFF
--- a/components/DomainManager.tsx
+++ b/components/DomainManager.tsx
@@ -43,13 +43,28 @@ export default function DomainManager() {
     setIsModalOpen(false);
   };
 
+  const unsecureCopyToClipboard = (text: string) => {
+    const textArea = document.createElement("textarea");
+    textArea.value = text;
+    document.body.appendChild(textArea);
+    textArea.focus();
+    textArea.select();
+    document.execCommand("copy");
+    document.body.removeChild(textArea);
+  }
+
   const copyToClipboard = (text: string) => {
-    navigator.clipboard.writeText(text);
+    if(navigator.clipboard || window.isSecureContext) {
+      navigator.clipboard.writeText(text);
+    } else {
+      unsecureCopyToClipboard(text);
+    }
     toast.success("Copied to clipboard!", {
       position: "bottom-center",
       autoClose: 2000,
     });
   };
+
   const handleLoadData = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (file) {


### PR DESCRIPTION
According to [MDN Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard)
`navigator.clipboard` is only available when under HTTPS, so I add another unsecure way to make copy works again under HTTP.
Reference : [StackOverflow - copy-text-to-clipboard-cannot-read-properties-of-undefined-reading-writetext](https://stackoverflow.com/questions/71873824/copy-text-to-clipboard-cannot-read-properties-of-undefined-reading-writetext)