### PR TITLE
Add UX features

### DIFF
--- a/components/DomainManager.tsx
+++ b/components/DomainManager.tsx
@@ -106,12 +106,21 @@ export default function DomainManager() {
     }
   };
 
+  // When targetHost is not set and the type is local, set targetHost as the local host
+
+  useEffect(() => {
+    if (!targetHost && selectedAccount?.type === "local") {
+      setTargetHost(selectedAccount.host);
+    }
+  }, [selectedAccount]);
+
   const renderCommands = () => {
     if (!selectedAccount || !selectedDomain) return null;
 
     const applicableCommands =
       selectedAccount.type === "local" ? localCommands : domainCommands;
 
+<<<<<<< HEAD
     return applicableCommands
       .filter((command) => command.template.includes(searchTerm))
       .map((command, index) => {

--- a/components/DomainManager.tsx
+++ b/components/DomainManager.tsx
@@ -108,14 +108,15 @@ export default function DomainManager() {
 
   // When targetHost is not set and the type is local, set targetHost as the local host
 
-  useEffect(() => {
-    if (!targetHost && selectedAccount?.type === "local") {
-      setTargetHost(selectedAccount.host);
-    }
-  }, [selectedAccount]);
 
   const renderCommands = () => {
     if (!selectedAccount || !selectedDomain) return null;
+
+    useEffect(() => {
+      if (!targetHost && selectedAccount?.type === "local") {
+        setTargetHost(selectedAccount.host);
+      }
+    }, [selectedAccount]);
 
     const applicableCommands =
       selectedAccount.type === "local" ? localCommands : domainCommands;

--- a/config/commands.domain.ts
+++ b/config/commands.domain.ts
@@ -82,6 +82,10 @@ const domainCommands: Command[] = [
       "xfreerdp /u:'{username}' /d:'{domain}' /pth:'{ntlmHash}' /v:'{targetHost}' /cert-ignore /dynamic-resolution",
     authType: "ntlmHash",
   },
+  {
+    template: "evil-winrm -u '{username}' -H '{ntlmHash}' -i '{targetHost}'",
+    authType: "ntlmHash",
+  },
 ];
 
 export default domainCommands;


### PR DESCRIPTION
1. Autofill the local host information when column is empty.
2. Re-index `xfreerdp` and `evil-winrm` at NTLM mode in template.
3. Add `impacket-mssqlclient` template