### PR TITLE
Fix bug caused by single quote in input

### DIFF
--- a/hooks/useCommands.ts
+++ b/hooks/useCommands.ts
@@ -54,7 +54,7 @@ export const useCommands = ({
   }, []);
 
   const sanitizeValue = useCallback((value: string): string => {
-    return value.replace(/'/g, "\\'");
+    return value.replace(/'/g, `'"'"'`);
   }, []);
 
   const getFilteredCommands = useCallback((): CommandWithText[] => {


### PR DESCRIPTION
If a user employs a password containing an apostrophe `'`, it may disrupt the commands generated by `impacket-smbclient`.

This pull request addresses that issue.